### PR TITLE
Upgrade to 0.9.9

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -9,7 +9,7 @@ CACHE_DIR=$2
 DEPS_DIR=$3
 INDEX=$4
 
-VULS_VERSION=${VULS_VERSION:-0.9.8}
+VULS_VERSION=${VULS_VERSION:-0.9.9}
 VULS_URL="${VULS_URL:-https://github.com/future-architect/vuls/releases/download/v${VULS_VERSION}/vuls_${VULS_VERSION}_linux_amd64.tar.gz}"
 VULS_DIR=$DEPS_DIR/$INDEX
 


### PR DESCRIPTION
Upgrade vuls to 0.9.9 to evaluate future-architect/vuls#1012.