### PR TITLE
Update default vuls binary to v0.11.0.

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -9,7 +9,7 @@ CACHE_DIR=$2
 DEPS_DIR=$3
 INDEX=$4
 
-VULS_VERSION=${VULS_VERSION:-0.9.9}
+VULS_VERSION=${VULS_VERSION:-0.11.0}
 VULS_URL="${VULS_URL:-https://github.com/future-architect/vuls/releases/download/v${VULS_VERSION}/vuls_${VULS_VERSION}_linux_amd64.tar.gz}"
 VULS_DIR=$DEPS_DIR/$INDEX
 


### PR DESCRIPTION
Coincide with flexion/10x-dux-vuls-eval#16.